### PR TITLE
Spike on push notifications webview javascript

### DIFF
--- a/app/src/main/java/org/xmtp/androidpushtest/MainActivity.kt
+++ b/app/src/main/java/org/xmtp/androidpushtest/MainActivity.kt
@@ -1,0 +1,38 @@
+package org.xmtp.androidpushtest
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.Settings
+import androidx.appcompat.app.AppCompatActivity
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+class MainActivity : AppCompatActivity() {
+    companion object {
+        private const val PERMISSION_REQUEST_CODE = 100
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        PushNotificationTokenManager.init(this)
+        GlobalScope.launch(Dispatchers.IO) {
+            PushNotificationTokenManager.ensurePushTokenIsConfigured()
+        }
+        setContentView(R.layout.activity_main)
+
+    // Uncomment this at least once to set the permissions up for requesting action overlay
+        // requestOverlayPermission()
+    }
+
+    private fun requestOverlayPermission() {
+        val myIntent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION)
+        myIntent.data = Uri.parse("package:$packageName")
+        startActivityForResult(myIntent, PERMISSION_REQUEST_CODE)
+    }
+}

--- a/app/src/main/java/org/xmtp/androidpushtest/PushNotificationTokenManager.kt
+++ b/app/src/main/java/org/xmtp/androidpushtest/PushNotificationTokenManager.kt
@@ -1,0 +1,47 @@
+package org.xmtp.androidpushtest
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingService
+
+object PushNotificationTokenManager {
+
+    private const val TAG = "PushTokenManager"
+    private lateinit var applicationContext: Context
+
+    fun init(applicationContext: Context) {
+        this.applicationContext = applicationContext
+    }
+
+    fun ensurePushTokenIsConfigured() {
+        FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener {
+            if (!it.isSuccessful) {
+                Log.e(TAG, "Firebase getInstanceId() failed", it.exception)
+                return@OnCompleteListener
+            }
+            it.result?.let {
+                // put a breakpoint here to get the token so you can trigger notifications from curl
+                val token = it
+                configureNotificationChannels()
+            }
+        })
+    }
+
+
+    private fun configureNotificationChannels() {
+        val channel = NotificationChannel(
+            PushNotificationsService.CHANNEL_ID,
+            "xmtp push test",
+            NotificationManager.IMPORTANCE_DEFAULT
+        )
+
+        val notificationManager = applicationContext.getSystemService(
+            FirebaseMessagingService.NOTIFICATION_SERVICE
+        ) as NotificationManager
+        notificationManager.createNotificationChannel(channel)
+    }
+}

--- a/app/src/main/java/org/xmtp/androidpushtest/PushNotificationsService.kt
+++ b/app/src/main/java/org/xmtp/androidpushtest/PushNotificationsService.kt
@@ -1,0 +1,155 @@
+package org.xmtp.androidpushtest
+
+import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.graphics.PixelFormat
+import android.os.HandlerThread
+import android.util.Log
+import android.view.Gravity
+import android.view.ViewGroup
+import android.view.WindowManager
+import android.webkit.JavascriptInterface
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+
+class PushNotificationsService : FirebaseMessagingService() {
+    companion object {
+        private const val TAG = "PushNotificationService"
+
+        internal const val CHANNEL_ID = "xmtp_android_push_test"
+    }
+
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+    }
+
+    /**
+     * Note: Notifications must be data messages so that this is called on all notifications
+     *
+     * https://firebase.google.com/docs/cloud-messaging/android/receive#handling_messages
+     */
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        super.onMessageReceived(remoteMessage)
+        Log.d(TAG, "On message received.")
+        val webAppInt = WebAppInterface(this@PushNotificationsService)
+
+        val handlerThread = object : HandlerThread("WEBVIEW_LOOPER") {
+            @SuppressLint("SetJavaScriptEnabled")
+            override fun onLooperPrepared() {
+                val windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
+                val params = WindowManager.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY, WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                            or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
+                    PixelFormat.TRANSLUCENT
+                )
+
+                params.gravity = Gravity.TOP or Gravity.START
+                params.x = 0
+                params.y = 0
+                params.width = 0
+                params.height = 0
+
+                val wv = WebView(this@PushNotificationsService)
+
+                wv.webViewClient = object : WebViewClient() {
+                    override fun onReceivedError(
+                        view: WebView,
+                        request: WebResourceRequest,
+                        error: WebResourceError
+                    ) {
+                        Log.d("Error", "loading web view: request: $request error: $error")
+                    }
+
+                    override fun shouldInterceptRequest(
+                        view: WebView,
+                        request: WebResourceRequest
+                    ): WebResourceResponse? {
+                        return if (request.url.toString().contains("/endProcess")) {
+                            windowManager.removeView(wv)
+                            wv.post { wv.destroy() }
+                            stopSelf()
+                            WebResourceResponse("bgsType", "someEncoding", null)
+                        } else {
+                            null
+                        }
+                    }
+                }
+                wv.settings.userAgentString = System.getProperty("http.agent") + "MyCloud"
+                wv.loadUrl("file:///android_asset/main.html")
+
+                wv.settings.javaScriptEnabled = true
+
+                wv.addJavascriptInterface(webAppInt, "Android");
+                windowManager.addView(wv, params)
+            }
+        }
+
+        if (!handlerThread.isAlive) {
+            handlerThread.start()
+        }
+
+        GlobalScope.launch(Dispatchers.Main) {
+            webAppInt.data.observeForever { addedNumber ->
+                val pendingIntent = PendingIntent.getActivity(
+                    this@PushNotificationsService,
+                    0,
+                    Intent(this@PushNotificationsService, MainActivity::class.java).apply {
+                        putExtra(
+                            "number",
+                            addedNumber
+                        )
+                    },
+                    (PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
+                )
+
+                val builder = NotificationCompat.Builder(this@PushNotificationsService, CHANNEL_ID)
+                    .setContentTitle(addedNumber)
+                    .setContentText(addedNumber)
+                    .setSmallIcon(R.drawable.ic_launcher_foreground)
+                    .setAutoCancel(true)
+                    .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                    .setStyle(NotificationCompat.BigTextStyle().bigText(addedNumber))
+                    .setContentIntent(pendingIntent)
+
+                // Use the number as the ID for now until one is passed back from the server.
+                NotificationManagerCompat.from(this@PushNotificationsService).apply {
+                    notify(addedNumber.hashCode(), builder.build())
+                }
+            }
+        }
+    }
+}
+
+class WebAppInterface internal constructor(ctx: Context) {
+    var mContext: Context
+    private val _data: MutableLiveData<String> =
+        MutableLiveData()
+    val data: LiveData<String>
+        get() = _data
+
+    init {
+        mContext = ctx
+    }
+
+    @JavascriptInterface
+    fun sendData(number: String?) {
+        _data.postValue(number)
+    }
+}


### PR DESCRIPTION
To test this use a data message by running this curl command

```
curl --location --request POST 'https://fcm.googleapis.com/fcm/send' \
--header 'Authorization: key=SERVER_TOKEN' \
--header 'Content-Type: application/json ' \
--data-raw '{
"to" : "FCM_TOKEN",
"data" : {
    "body" : "Body of Your Notification in Data",
    "title": "Title of Your Notification in Title",
    "key_1" : "Value for key_1",
    "key_2" : "Value for key_2"
}
}'
```

this should work for both background and foreground situations. 

You can watch a demo explanation here: https://xmtp.rewatch.com/video/2u3jhzfk8npincdy-android-web-view-push-demo